### PR TITLE
Move spec status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Proposals follow [this process document](https://github.com/WebAssembly/meetings
 
 ## Standardized proposals
 
-| Proposal                                                             | Champion  |
-| -------------------------------------------------------------------- | --------- |
-| [Import/Export of Mutable Globals][import_export_of_mutable_globals] | Ben Smith |
+| Proposal                                                             | Champion         |
+| -------------------------------------------------------------------- | ---------------- |
+| [WebAssembly specification][webassembly_specification]               | Andreas Rossberg |
+| [Import/Export of Mutable Globals][import_export_of_mutable_globals] | Ben Smith        |
 
 ## Active proposals
 
@@ -30,7 +31,6 @@ Proposals follow [this process document](https://github.com/WebAssembly/meetings
 | Proposal                                                                                             | Champion         |
 | ---------------------------------------------------------------------------------------------------- | ---------------- |
 | [JavaScript BigInt to WebAssembly i64 integration][javascript_bigint_to_webassembly_i64_integration] | Dan Ehrenberg    |
-| [WebAssembly specification][webassembly_specification]                                               | Andreas Rossberg |
 | [Bulk memory operations][bulk_memory_operations]                                                     | Ben Smith        |
 | [Threads][threads]                                                                                   | Ben Smith        |
 


### PR DESCRIPTION
Move status of spec to "Accepted", which seems more accurate than Stage 2. Logically it should be at least as far along as any proposals that have been accepted into it.