### PR TITLE
Unify links to proposal repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,28 +60,28 @@ Proposals follow [this process document](https://github.com/WebAssembly/meetings
 
 Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/blob/master/Contributing.md) for the most up-to-date information on contributing proposals to standard.
 
-[bulk_memory_operations]: https://github.com/webassembly/bulk-memory-operations
-[custom_annotation_syntax_in_the_text_format]: https://github.com/WebAssembly/annotations/blob/master/proposals/annotations/Overview.md
-[ecmascript_module_integration]: https://github.com/webassembly/esm-integration
-[exception_handling]: https://github.com/WebAssembly/exception-handling/blob/master/proposals/Exceptions.md
-[fixed-width_simd]: https://github.com/webassembly/simd/blob/master/proposals/simd/SIMD.md
+[bulk_memory_operations]: https://github.com/WebAssembly/bulk-memory-operations
+[custom_annotation_syntax_in_the_text_format]: https://github.com/WebAssembly/annotations
+[ecmascript_module_integration]: https://github.com/WebAssembly/esm-integration
+[exception_handling]: https://github.com/WebAssembly/exception-handling
+[fixed-width_simd]: https://github.com/webassembly/simd
 [function_references]: https://github.com/WebAssembly/function-references
 [type-imports]: https://github.com/WebAssembly/proposal-type-imports
-[garbage_collection]: https://github.com/webassembly/gc/blob/master/proposals/gc/Overview.md
-[interface_types]: https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md
+[garbage_collection]: https://github.com/WebAssembly/gc
+[interface_types]: https://github.com/WebAssembly/interface-types
 [javascript_bigint_to_webassembly_i64_integration]: https://github.com/WebAssembly/JS-BigInt-integration
 [non-trapping_float-to-int_conversions]: https://github.com/WebAssembly/nontrapping-float-to-int-conversions
 [multi-value]: https://github.com/WebAssembly/multi-value
 [multi-memory]: https://github.com/WebAssembly/multi-memory
 [reference_types]: https://github.com/WebAssembly/reference-types
-[sign-extension_operators]: https://github.com/WebAssembly/sign-extension-ops/blob/master/proposals/sign-extension-ops/Overview.md
-[tail_call]: https://github.com/webassembly/tail-call
-[threads]: https://github.com/webassembly/threads/blob/master/proposals/threads/Overview.md
-[type_reflection_for_webassembly_javascript_api]: https://github.com/webassembly/js-types/blob/master/proposals/js-types/Overview.md
+[sign-extension_operators]: https://github.com/WebAssembly/sign-extension-ops
+[tail_call]: https://github.com/WebAssembly/tail-call
+[threads]: https://github.com/webassembly/threads
+[type_reflection_for_webassembly_javascript_api]: https://github.com/WebAssembly/js-types
 [wasm_c_api]: https://github.com/WebAssembly/wasm-c-api
-[web_content_security_policy]: https://github.com/WebAssembly/content-security-policy/blob/master/proposals/CSP.md
+[web_content_security_policy]: https://github.com/WebAssembly/content-security-policy
 [webassembly_specification]: https://github.com/WebAssembly/spec
 [funclets]: https://github.com/WebAssembly/funclets
 [feature_detection]: https://github.com/WebAssembly/feature-detection
-[extended-name-section]: https://github.com/WebAssembly/extended-name-section/blob/master/proposals/extended-name-section/Overview.md
-[module_types]: https://github.com/WebAssembly/module-types/blob/master/proposals/module-types/Overview.md
+[extended-name-section]: https://github.com/WebAssembly/extended-name-section
+[module_types]: https://github.com/WebAssembly/module-types


### PR DESCRIPTION
1) Use "github.com/WebAssembly" consistently (instead of "github.com/webassembly").
2) Always link to the repository itself instead of (sometimes) the overview page. The main README should prominently link to the overview anyway.