### PR TITLE
Update JS-bigint to wasm i64 integration proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Proposals follow [this process document](https://github.com/WebAssembly/meetings
 | [Reference Types][reference_types]                                                                   | Andreas Rossberg                       |
 | [Tail call][tail_call]                                                                               | Andreas Rossberg                       |
 | [Bulk memory operations][bulk_memory_operations]                                                     | Ben Smith                              |
-| [JavaScript BigInt to WebAssembly i64 integration][javascript_bigint_to_webassembly_i64_integration] | Dan Ehrenberg & Sven Sauleau           |
 | [Fixed-width SIMD][fixed-width_simd]                                                                 | Deepti Gandluri and Arun Purushan      |
 | [Multiple memories][multi-memory]                                                                    | Andreas Rossberg                       |
 | [Custom Annotation Syntax in the Text Format][custom_annotation_syntax_in_the_text_format]           | Andreas Rossberg                       |
@@ -69,7 +68,6 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/b
 [type-imports]: https://github.com/WebAssembly/proposal-type-imports
 [garbage_collection]: https://github.com/WebAssembly/gc
 [interface_types]: https://github.com/WebAssembly/interface-types
-[javascript_bigint_to_webassembly_i64_integration]: https://github.com/WebAssembly/JS-BigInt-integration
 [multi-memory]: https://github.com/WebAssembly/multi-memory
 [reference_types]: https://github.com/WebAssembly/reference-types
 [tail_call]: https://github.com/WebAssembly/tail-call

--- a/finished-proposals.md
+++ b/finished-proposals.md
@@ -8,6 +8,7 @@ Finished proposals are proposals that have reached phase 4, and are included in 
 | [Non-trapping float-to-int conversions][non-trapping_float-to-int_conversions] | Dan Gohman       | [WG-03-11][] |
 | [Sign-extension operators][sign-extension_operators]                           | Ben Smith        | [WG-03-11][] |
 | [Multi-value][multi-value]                                                     | Andreas Rossberg | [WG-03-11][] |
+| [JavaScript BigInt to WebAssembly i64 integration][javascript_bigint_to_webassembly_i64_integration] | Dan Ehrenberg & Sven Sauleau           | [WG-06-09][]
 
 See also the [active proposals](README.md) and [inactive proposals](inactive-proposals.md) documents.
 
@@ -15,5 +16,7 @@ See also the [active proposals](README.md) and [inactive proposals](inactive-pro
 [non-trapping_float-to-int_conversions]: https://github.com/WebAssembly/nontrapping-float-to-int-conversions
 [sign-extension_operators]: https://github.com/WebAssembly/sign-extension-ops
 [multi-value]: https://github.com/WebAssembly/multi-value
+[javascript_bigint_to_webassembly_i64_integration]: https://github.com/WebAssembly/JS-BigInt-integration
 [wg-06-06]: https://github.com/WebAssembly/meetings/blob/master/2018/WG-06-06.md#discussion-on-status-of-the-working-draft
 [WG-03-11]: https://github.com/WebAssembly/meetings/blob/master/2020/WG-03-11.md
+[WG-06-09]: https://lists.w3.org/Archives/Public/public-webassembly/2020Jun/0000.html


### PR DESCRIPTION
It is now a phase 5 proposal.