### PR TITLE
Add gc-js-customization as a phase 0 proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | [Funclets: Flexible Intraprocedural Control Flow][funclets] | Dan Gohman                       |
 | [JS Customization of GC Objects][gc-js-customization]       |                                  |
 
-
 ## Implementation status
 
 Roadmap is available on https://webassembly.org/roadmap/
@@ -110,6 +109,6 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/b
 [relaxed-simd]: https://github.com/WebAssembly/relaxed-simd
 [stack-switching]: https://github.com/WebAssembly/stack-switching
 [js-promise-integration]: https://github.com/WebAssembly/js-promise-integration
+[gc-js-customization]: https://github.com/WebAssembly/gc-js-customization
 [memory-control]: https://github.com/WebAssembly/memory-control
 [stringref]: https://github.com/WebAssembly/stringref
-[gc-js-customization]: https://github.com/WebAssembly/gc-js-customization

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | Proposal                                                   | Champion                         |
 | ---------------------------------------------------------- | -------------------------------- |
 | [Funclets: Flexible Intraprocedural Control Flow][funclets]| Dan Gohman                       |
+| [JS Customization of GC Objects][gc-js-customization]      |                                  |
 
 ## Implementation status
 
@@ -106,3 +107,4 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/b
 [relaxed-simd]: https://github.com/WebAssembly/relaxed-simd
 [stack-switching]: https://github.com/WebAssembly/stack-switching
 [js-promise-integration]: https://github.com/WebAssembly/js-promise-integration
+[gc-js-customization]: https://github.com/WebAssembly/gc-js-customization


### PR DESCRIPTION
The GC subgroup decided to split the customization of JS accessors and prototypes for GC objects out into a separate proposal.