### PR TITLE
Update champions for ESM integration proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | Proposal                                                                                             | Champion                               |
 | ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
 | [Threads][threads]                                                                                   | Conrad Watt                            |
-| [ECMAScript module integration][ecmascript_module_integration]                                       | Lin Clark & Daniel Ehrenberg           |
+| [ECMAScript module integration][ecmascript_module_integration]                                       | Asumu Takikawa & Ms2ger                |
 | [Type Reflection for WebAssembly JavaScript API][type_reflection_for_webassembly_javascript_api]     | Till Schneidereit                      |
 | [Typed Function References][function_references]                                                     | Andreas Rossberg                       |
 | [Relaxed dead code validation][relaxed-dead-code-validation]                                         | Conrad Watt and Ross Tate              |


### PR DESCRIPTION
PR to update the list of champions for the ESM integration proposal.

Myself and Ms2ger have been taking over the work that @littledan was doing on this proposal at Igalia, and we've also checked in with @linclark as well for this change. Thanks to both of them for developing the proposal to this point!