### PR TITLE
Add component-model, mark module-linking and interface-types as inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,12 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | Proposal                                                   | Champion                                                                          |
 |------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | [Type Imports][type-imports]                               | Andreas Rossberg                                                                  |
-| [Interface Types][interface_types]                         | Luke Wagner and Francis McCabe                                                    |
+| [Component Model][component-model]                         | Luke Wagner                                                                       |
 | [WebAssembly C and C++ API][wasm_c_api]                    | Andreas Rossberg                                                                  |
 | [Feature Detection][feature_detection]                     | Thomas Lively                                                                     |
 | [Extended Name Section][extended-name-section]             | Andrew Scheidecker                                                                |
 | [Flexible Vectors][flexible-vectors]                       | Petr Penzin                                                                       |
 | [Call Tags][call-tags]                                     | Ross Tate                                                                         |
-| [Module Linking][module_linking]                           | Luke Wagner and Andreas Rossberg                                                  |
 | [Stack Switching][stack-switching]                         | Francis McCabe & Sam Lindley                                                      |
 | [Constant Time][constant-time]                             | Sunjay Cauligi, Garrett Gu, John Renner, Hovav Shacham, Deian Stefan, Conrad Watt |
 | [JS Customization for GC Objects][gc-js-customization]     | Asumu Takikawa                                                                    |
@@ -86,7 +85,7 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/b
 [function_references]: https://github.com/WebAssembly/function-references
 [type-imports]: https://github.com/WebAssembly/proposal-type-imports
 [garbage_collection]: https://github.com/WebAssembly/gc
-[interface_types]: https://github.com/WebAssembly/interface-types
+[component-model]: https://github.com/WebAssembly/component-model
 [multi-memory]: https://github.com/WebAssembly/multi-memory
 [tail_call]: https://github.com/WebAssembly/tail-call
 [threads]: https://github.com/webassembly/threads
@@ -96,7 +95,6 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/b
 [webassembly_specification]: https://github.com/WebAssembly/spec
 [funclets]: https://github.com/WebAssembly/funclets
 [extended-name-section]: https://github.com/WebAssembly/extended-name-section
-[module_linking]: https://github.com/WebAssembly/module-linking
 [constant-time]: https://github.com/WebAssembly/constant-time
 [memory64]: https://github.com/WebAssembly/memory64
 [flexible-vectors]: https://github.com/WebAssembly/flexible-vectors

--- a/inactive-proposals.md
+++ b/inactive-proposals.md
@@ -6,6 +6,8 @@ Inactive proposals are proposals that at one point were presented to the communi
 | ---------------------------------------- | ---------------- | ---------------------------------------------------------------------- |
 | [Unmanaged closures][unmanaged_closures] | Mark Miller      | Withdrawn in favor of [Typed Function References][function_references] |
 | [Conditional sections][cond_sections]    | Thomas Lively    | Withdrawn in favor of [Feature detection][feature_detection]           |
+| [Module Linking][module_linking]         | Luke Wagner and Andreas Rossberg | Suspended in favor of the [Component Model][component_model] |
+| [Interface Types][interface_types]       | Luke Wagner and Francis McCabe |  Suspended in favor of the [Component Model][component_model] |
 
 See also the [active proposals](README.md) and [finished proposals](finished-proposals.md) documents.
 
@@ -13,3 +15,6 @@ See also the [active proposals](README.md) and [finished proposals](finished-pro
 [function_references]: https://github.com/WebAssembly/function-references
 [cond_sections]: https://github.com/WebAssembly/conditional-sections
 [feature_detection]: https://github.com/WebAssembly/feature-detection
+[module_linking]: https://github.com/WebAssembly/module-linking
+[interface_types]: https://github.com/WebAssembly/interface-types
+[component_model]: https://github.com/WebAssembly/component-model


### PR DESCRIPTION
The [component-model](github.com/webAssembly/component-model/) repo is (finally) in a shape to subsume the contents of the [module-linking](https://github.com/webAssembly/module-linking/) and [interface-types](https://github.com/WebAssembly/interface-types/) repo, so this PR updates/merges these two proposals into one, as proposed to the CG [last May](https://github.com/WebAssembly/meetings/blob/main/main/2021/CG-05-25.md).  The champions are also updated according to discussions with @rossberg and @fgmccabe (although both folks are still meeting and helping regularly).  Note: while module-linking and interface-types are currently inactive, these repos both have a hopeful reason to become active again in the future (as described in each of their respective README.md's).