### PR TITLE
Move funclets to the list of inactive proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 
 | Proposal                                                    | Champion                         |
 | ----------------------------------------------------------- | -------------------------------- |
-| [Funclets: Flexible Intraprocedural Control Flow][funclets] | Dan Gohman                       |
 
 ## Implementation status
 
@@ -93,7 +92,6 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/b
 [wasm_c_api]: https://github.com/WebAssembly/wasm-c-api
 [content-security-policy]: https://github.com/WebAssembly/content-security-policy
 [webassembly_specification]: https://github.com/WebAssembly/spec
-[funclets]: https://github.com/WebAssembly/funclets
 [extended-name-section]: https://github.com/WebAssembly/extended-name-section
 [constant-time]: https://github.com/WebAssembly/constant-time
 [memory64]: https://github.com/WebAssembly/memory64

--- a/inactive-proposals.md
+++ b/inactive-proposals.md
@@ -8,7 +8,9 @@ Inactive proposals are proposals that at one point were presented to the communi
 | [Conditional sections][cond_sections]    | Thomas Lively    | Withdrawn in favor of [Feature detection][feature_detection]           |
 | [Feature Detection][feature_detection]   | Thomas Lively    | Withdrawn for lack of consensus                                        |
 | [Module Linking][module_linking]         | Luke Wagner and Andreas Rossberg | Suspended in favor of the [Component Model][component_model] |
-| [Interface Types][interface_types]       | Luke Wagner and Francis McCabe |  Suspended in favor of the [Component Model][component_model] |
+| [Interface Types][interface_types]       | Luke Wagner and Francis McCabe | Suspended in favor of the [Component Model][component_model] |
+| [Funclets: Flexible Intraprocedural Control Flow][funclets] | Dan Gohman  | Withdrawn in favor of multiloop                          |
+
 
 See also the [active proposals](README.md) and [finished proposals](finished-proposals.md) documents.
 
@@ -19,3 +21,4 @@ See also the [active proposals](README.md) and [finished proposals](finished-pro
 [module_linking]: https://github.com/WebAssembly/module-linking
 [interface_types]: https://github.com/WebAssembly/interface-types
 [component_model]: https://github.com/WebAssembly/component-model
+[funclets]: https://github.com/WebAssembly/funclets


### PR DESCRIPTION
It is [no longer being worked
on](https://github.com/WebAssembly/design/issues/1227#issuecomment-1295490123) and there is consensus that multiloop would be a better way to achieve the same goals.