### PR TITLE
Move Call Tags, Constant Time, and JS Customization to inactive list

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | [Component Model][component-model]                     | Luke Wagner                                                                       |
 | [WebAssembly C and C++ API][wasm_c_api]                | Andreas Rossberg                                                                  |
 | [Flexible Vectors][flexible-vectors]                   | Petr Penzin & Tal Garfinkel                                                       |
-| [Call Tags][call-tags]                                 | Ross Tate                                                                         |
-| [Constant Time][constant-time]                         | Sunjay Cauligi, Garrett Gu, John Renner, Hovav Shacham, Deian Stefan, Conrad Watt |
-| [JS Customization for GC Objects][gc-js-customization] | Asumu Takikawa                                                                    |
 | [Memory control][memory-control]                       | Deepti Gandluri & Ben Visness                                                     |
 | [Reference-Typed Strings][stringref]                   | Andy Wingo                                                                        |
 | [Profiles][profiles]                                   | Andreas Rossberg                                                                  |
@@ -104,19 +101,16 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/design/b
 [content-security-policy]: https://github.com/WebAssembly/content-security-policy
 [webassembly_specification]: https://github.com/WebAssembly/spec
 [extended-name-section]: https://github.com/WebAssembly/extended-name-section
-[constant-time]: https://github.com/WebAssembly/constant-time
 [memory64]: https://github.com/WebAssembly/memory64
 [flexible-vectors]: https://github.com/WebAssembly/flexible-vectors
 [numeric-values-in-wat]: https://github.com/WebAssembly/wat-numeric-values
 [instrument-tracing]: https://github.com/WebAssembly/instrument-tracing
-[call-tags]: https://github.com/WebAssembly/call-tags
 [relaxed-dead-code-validation]: https://github.com/WebAssembly/relaxed-dead-code-validation
 [branch-hinting]: https://github.com/WebAssembly/branch-hinting
 [extended-const]: https://github.com/WebAssembly/extended-const
 [relaxed-simd]: https://github.com/WebAssembly/relaxed-simd
 [stack-switching]: https://github.com/WebAssembly/stack-switching
 [js-promise-integration]: https://github.com/WebAssembly/js-promise-integration
-[gc-js-customization]: https://github.com/WebAssembly/gc-js-customization
 [memory-control]: https://github.com/WebAssembly/memory-control
 [stringref]: https://github.com/WebAssembly/stringref
 [profiles]: https://github.com/WebAssembly/profiles

--- a/inactive-proposals.md
+++ b/inactive-proposals.md
@@ -10,6 +10,9 @@ Inactive proposals are proposals that at one point were presented to the communi
 | [Module Linking][module_linking]         | Luke Wagner and Andreas Rossberg | Suspended in favor of the [Component Model][component_model] |
 | [Interface Types][interface_types]       | Luke Wagner and Francis McCabe | Suspended in favor of the [Component Model][component_model] |
 | [Funclets: Flexible Intraprocedural Control Flow][funclets] | Dan Gohman  | Withdrawn in favor of multiloop[[1][multiloop-1]][[2][multiloop-2]] |
+| [Call Tags][call-tags]                                      | Ross Tate   | Inactive                                                            |
+| [Constant Time][constant-time]                              | Sunjay Cauligi, Garrett Gu, John Renner, Hovav Shacham, Deian Stefan, Conrad Watt | Inactive |
+| [JS Customization for GC Objects][gc-js-customization]      | Asumu Takikawa | Withdrawn in favor of [Custom Descriptors][custom-descs] |
 
 
 See also the [active proposals](README.md) and [finished proposals](finished-proposals.md) documents.
@@ -24,3 +27,7 @@ See also the [active proposals](README.md) and [finished proposals](finished-pro
 [funclets]: https://github.com/WebAssembly/funclets
 [multiloop-1]: https://github.com/WebAssembly/meetings/blob/8f06ff4d8c1f8af28a37fd1f2ab4b7df30741f76/main/2021/CG-03-16.md
 [multiloop-2]: https://github.com/WebAssembly/meetings/blob/8f06ff4d8c1f8af28a37fd1f2ab4b7df30741f76/main/2021/CG-03-30.md
+[call-tags]: https://github.com/WebAssembly/call-tags
+[constant-time]: https://github.com/WebAssembly/constant-time
+[gc-js-customization]: https://github.com/WebAssembly/gc-js-customization
+[custom-descs]: https://github.com/WebAssembly/custom-descriptors


### PR DESCRIPTION
These proposals are not actively being worked on. JS Customization for
GC Objects has additionally been superseded by Custom Descriptors and JS
Interop.
