### PR TITLE
Use date formats consistently in finished-proposals.md.

### DIFF
--- a/finished-proposals.md
+++ b/finished-proposals.md
@@ -4,14 +4,14 @@ Finished proposals are proposals that have reached phase 4, and are included in 
 
 | Proposal                                                             | Champion         | Meeting notes        | Affected specs |
 | -------------------------------------------------------------------- | ---------------- | ---------------------|----------------
-| [Import/Export of Mutable Globals][import_export_of_mutable_globals] | Ben Smith        | [WG 2018-06-06][WG-06-06] | core, js-api
-| [Non-trapping float-to-int conversions][non-trapping_float-to-int_conversions] | Dan Gohman       | [WG 2020-03-11][WG-03-11] | core
-| [Sign-extension operators][sign-extension_operators]                           | Ben Smith        | [WG 2020-03-11][WG-03-11] | core
-| [Multi-value][multi-value]                                                     | Andreas Rossberg | [WG 2020-03-11][WG-03-11] | core, js-api
-| [JavaScript BigInt to WebAssembly i64 integration][javascript_bigint_to_webassembly_i64_integration] | Dan Ehrenberg & Sven Sauleau           | [WG 2020-06-09][WG-06-09] | js-api
-| [Reference Types][reference_types]                                             | Andreas Rossberg | [WG 2021-02-10][WG-02-10-2021] | core, js-api
-| [Bulk memory operations][bulk_memory_operations]                               | Ben Smith        | [WG 2021-02-10][WG-02-10-2021] | core
-| [Fixed-width SIMD][fixed-width_simd]                                           | Deepti Gandluri and Arun Purushan | [WG 2021-07-14][WG-07-14-2021] | core, js-api
+| [Import/Export of Mutable Globals][import_export_of_mutable_globals] | Ben Smith        | [WG 2018-06-06][WG-2018-06-06] | core, js-api
+| [Non-trapping float-to-int conversions][non-trapping_float-to-int_conversions] | Dan Gohman       | [WG 2020-03-11][WG-2020-03-11] | core
+| [Sign-extension operators][sign-extension_operators]                           | Ben Smith        | [WG 2020-03-11][WG-2020-03-11] | core
+| [Multi-value][multi-value]                                                     | Andreas Rossberg | [WG 2020-03-11][WG-2020-03-11] | core, js-api
+| [JavaScript BigInt to WebAssembly i64 integration][javascript_bigint_to_webassembly_i64_integration] | Dan Ehrenberg & Sven Sauleau           | [WG 2020-06-09][WG-2020-06-09] | js-api
+| [Reference Types][reference_types]                                             | Andreas Rossberg | [WG 2021-02-10][WG-2021-02-10] | core, js-api
+| [Bulk memory operations][bulk_memory_operations]                               | Ben Smith        | [WG 2021-02-10][WG-2021-02-10] | core
+| [Fixed-width SIMD][fixed-width_simd]                                           | Deepti Gandluri and Arun Purushan | [WG 2021-07-14][WG-2021-07-14] | core, js-api
 
 See also the [active proposals](README.md) and [inactive proposals](inactive-proposals.md) documents.
 
@@ -23,8 +23,8 @@ See also the [active proposals](README.md) and [inactive proposals](inactive-pro
 [reference_types]: https://github.com/WebAssembly/reference-types
 [bulk_memory_operations]: https://github.com/WebAssembly/bulk-memory-operations
 [fixed-width_simd]: https://github.com/webassembly/simd
-[wg-06-06]: https://github.com/WebAssembly/meetings/blob/main/main/2018/WG-06-06.md#discussion-on-status-of-the-working-draft
-[WG-03-11]: https://github.com/WebAssembly/meetings/blob/main/main/2020/WG-03-11.md
-[WG-06-09]: https://lists.w3.org/Archives/Public/public-webassembly/2020Jun/0000.html
-[WG-02-10-2021]: https://github.com/WebAssembly/meetings/blob/main/main/2021/WG-02-10.md
-[WG-07-14-2021]: https://github.com/WebAssembly/meetings/blob/main/main/2021/WG-07-14.md
+[WG-2018-06-06]: https://github.com/WebAssembly/meetings/blob/main/main/2018/WG-06-06.md#discussion-on-status-of-the-working-draft
+[WG-2020-03-11]: https://github.com/WebAssembly/meetings/blob/main/main/2020/WG-03-11.md
+[WG-2020-06-09]: https://lists.w3.org/Archives/Public/public-webassembly/2020Jun/0000.html
+[WG-2021-02-10]: https://github.com/WebAssembly/meetings/blob/main/main/2021/WG-02-10.md
+[WG-2021-07-14]: https://github.com/WebAssembly/meetings/blob/main/main/2021/WG-07-14.md


### PR DESCRIPTION
Use yyyy-mm-dd instead of a mix of different date formats for link names in finished-proposals.md. This doesn't change any visible text; it just makes the markup tidier.