### PR TITLE
Add the MVP to the list of "finished proposals".

### DIFF
--- a/finished-proposals.md
+++ b/finished-proposals.md
@@ -4,6 +4,7 @@ Finished proposals are proposals that have reached phase 4, and are included in 
 
 | Proposal                                                             | Champion         | Meeting notes        | Affected specs |
 | -------------------------------------------------------------------- | ---------------- | ---------------------|----------------
+| [MVP][mvp]                                                           | The Wasm CG      | [WG 2017-12-06][WG-2017-12-06] | core, js-api, web-api
 | [Import/Export of Mutable Globals][import_export_of_mutable_globals] | Ben Smith        | [WG 2018-06-06][WG-2018-06-06] | core, js-api
 | [Non-trapping float-to-int conversions][non-trapping_float-to-int_conversions] | Dan Gohman       | [WG 2020-03-11][WG-2020-03-11] | core
 | [Sign-extension operators][sign-extension_operators]                           | Ben Smith        | [WG 2020-03-11][WG-2020-03-11] | core
@@ -15,6 +16,7 @@ Finished proposals are proposals that have reached phase 4, and are included in 
 
 See also the [active proposals](README.md) and [inactive proposals](inactive-proposals.md) documents.
 
+[mvp]: https://github.com/WebAssembly/design/blob/main/MVP.md
 [import_export_of_mutable_globals]: https://github.com/WebAssembly/mutable-global
 [non-trapping_float-to-int_conversions]: https://github.com/WebAssembly/nontrapping-float-to-int-conversions
 [sign-extension_operators]: https://github.com/WebAssembly/sign-extension-ops
@@ -23,6 +25,7 @@ See also the [active proposals](README.md) and [inactive proposals](inactive-pro
 [reference_types]: https://github.com/WebAssembly/reference-types
 [bulk_memory_operations]: https://github.com/WebAssembly/bulk-memory-operations
 [fixed-width_simd]: https://github.com/webassembly/simd
+[WG-2017-12-06]: https://github.com/WebAssembly/meetings/blob/main/main/2017/WG-12-06.md
 [WG-2018-06-06]: https://github.com/WebAssembly/meetings/blob/main/main/2018/WG-06-06.md#discussion-on-status-of-the-working-draft
 [WG-2020-03-11]: https://github.com/WebAssembly/meetings/blob/main/main/2020/WG-03-11.md
 [WG-2020-06-09]: https://lists.w3.org/Archives/Public/public-webassembly/2020Jun/0000.html


### PR DESCRIPTION
The MVP wasn't a typical "proposal", however it was the source of many features in the specs today, in the same way that subsequent feature proposals are. And like all the other feature proposals, the MVP was designed in the CG, approved by the WG, and it had affected specs.

This makes the table complete in a sense, as it documents all the moments when features were added to specs, including the web-api spec which wasn't previously present in the table.