### PR TITLE
Move Exceptions, JS string builtins, and memory64 to phase 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | [Relaxed SIMD][relaxed-simd]                               | Marat Dukhan & Zhi An Ng |
 | [Custom Annotation Syntax in the Text Format][annotations] | Andreas Rossberg         |
 | [Branch Hinting][branch-hinting]                           | Yuri Iozzelli            |
+| [Exception handling][exception_handling]                   | Heejin Ahn & Ben Titzer  |
+| [JS String Builtins][js-string-builtins]                   | Ryan Hunt                |
+| [Memory64][memory64]                                       | Sam Clegg                |
 
 ### Phase 4 - Standardize the Feature (WG)
 
 | Proposal                                                   | Champion                 |
 | -----------------------------------------------------------| -------------------------|
 | [Threads][threads]                                         | Conrad Watt              |
-| [Exception handling][exception_handling]                   | Heejin Ahn & Ben Titzer  |
-| [JS String Builtins][js-string-builtins]                   | Ryan Hunt                |
-| [Memory64][memory64]                                       | Sam Clegg                |
 | [JS Promise Integration][js-promise-integration]           | Francis McCabe           |
 
 ### Phase 3 - Implementation Phase (CG + WG)


### PR DESCRIPTION
As approved in the July 23 WG meeting