### PR TITLE
Move custom-page-sizes proposal to phase 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | [Wide Arithmetic][wide-arithmetic]                         | Alex Crichton and Jamey Sharp        |
 | [Stack Switching][stack-switching]                         | Francis McCabe & Sam Lindley         |
 | [Compact Import Section][compact-import-section]               | Ryan Hunt                    |
+| [Custom Page Sizes][custom-page-sizes]                         | Nick Fitzgerald              |
 
 ### Phase 2 - Proposed Spec Text Available (CG + WG)
 
@@ -39,7 +40,6 @@ _These proposals have not yet been merged to the spec. Merged proposals are list
 | [Relaxed dead code validation][relaxed-dead-code-validation]   | Conrad Watt and Ross Tate    |
 | [Numeric Values in WAT Data Segments][numeric-values-in-wat]   | Ezzat Chamudi                |
 | [Extended Name Section][extended-name-section]                 | Ben Visness                  |
-| [Custom Page Sizes][custom-page-sizes]                         | Nick Fitzgerald              |
 | [Rounding Variants][rounding-mode-control]                     | Kloud Koder                  |
 | [Compilation Hints][compilation-hints]                         | Emanuel Ziegler              |
 | [Custom Descriptors and JS Interop][custom-descs]              | Thomas Lively                |


### PR DESCRIPTION
This happened quite some time ago and it seems we forgot to update it here.

https://github.com/WebAssembly/meetings/blob/main/main/2025/CG-03-25.md#update-on-the-custom-page-sizes-proposal-and-vote-for-phase-3-nick-fitzgerald-20-minutes